### PR TITLE
Python detector inference example cleanup.

### DIFF
--- a/classifiers/python_inference/infer.py
+++ b/classifiers/python_inference/infer.py
@@ -35,7 +35,7 @@ def main():
     args = parser.parse_args()
 
     # Load runtime
-    lre = LatentRuntimeEngine(str(Path(args.path_to_model) / "modelLibrary.so"))
+    lre = LatentRuntimeEngine(str(Path(args.model_binary_path) / "modelLibrary.so"))
     print(lre.get_metadata())
 
     # Set precision
@@ -49,7 +49,7 @@ def main():
     device = lre.device_type
 
     # Load image
-    input_image_path = args.input_image
+    input_image_path = args.input_image_path
     image = Image.open(input_image_path)
     
     # Apply preprocess transformations

--- a/classifiers/python_inference/inference_commands.bash
+++ b/classifiers/python_inference/inference_commands.bash
@@ -7,23 +7,26 @@
 
 #!/bin/bash
 
-FLOAT32_MODEL=~/models/timm-gernet_m/x86_64_cuda/Float32-compile
-INT8_MODEL=~/models/timm-gernet_m/x86_64_cuda/Int8-optimize
+FLOAT32_MODEL=$1
+INT8_MODEL=$2
+LABELS_PATH=$3
+IMAGE_PATH=../../sample_images/apple.jpg
 
 if [ -v MODEL_PATH ];
 then
-    FLOAT32_PACKAGE=$MODEL_PATH/Float32-package
-    INT8_PACKAGE=$MODEL_PATH/Int8-package
+    FLOAT32_PACKAGE=$MODEL_PATH/Float32-compile
+    INT8_PACKAGE=$MODEL_PATH/Int8-optimize
 fi
+INT8_ACTIVATIONS=$INT8_MODEL/.activations/ # can we throw an error if this does not exist?
 
 echo "FP32..."
 mkdir -p $FLOAT32_PACKAGE/trt-cache
-TVM_TENSORRT_CACHE_DIR=$FLOAT32_PACKAGE/trt-cache python3 infer.py --path_to_model $FLOAT32_MODEL --input_image ../../sample_images/apple.jpg --labels ../../labels/class_names_10.txt
+TVM_TENSORRT_CACHE_DIR=$FLOAT32_PACKAGE/trt-cache python3 infer.py --model_binary_path $FLOAT32_MODEL --input_image_path $IMAGE_PATH --labels $LABELS_PATH
 
 echo "FP16..."
 mkdir -p $FLOAT32_PACKAGE/trt-cache
-TVM_TENSORRT_CACHE_DIR=$FLOAT32_PACKAGE/trt-cache TVM_TENSORRT_USE_FP16=1 python3 infer.py --path_to_model $FLOAT32_MODEL --input_image ../../sample_images/apple.jpg --labels ../../labels/class_names_10.txt
+TVM_TENSORRT_CACHE_DIR=$FLOAT32_PACKAGE/trt-cache TVM_TENSORRT_USE_FP16=1 python3 infer.py --model_binary_path $FLOAT32_MODEL --input_image_path $IMAGE_PATH --labels $LABELS_PATH
 
 echo "INT8..."
 mkdir -p $INT8_PACKAGE/trt-cache
-TVM_TENSORRT_CACHE_DIR=$INT8_PACKAGE/trt-cache TVM_TENSORRT_USE_INT8=1 TRT_INT8_PATH=~/.latentai/LRE/.model/.activations/ python3 infer.py --path_to_model $INT8_MODEL --input_image ../../sample_images/apple.jpg --labels ../../labels/class_names_10.txt
+TVM_TENSORRT_CACHE_DIR=$INT8_PACKAGE/trt-cache TVM_TENSORRT_USE_INT8=1 TRT_INT8_PATH=$INT8_ACTIVATIONS python3 infer.py --model_binary_path $INT8_MODEL --input_image_path $IMAGE_PATH --labels $LABELS_PATH

--- a/detectors/python_inference/infer.py
+++ b/detectors/python_inference/infer.py
@@ -104,7 +104,7 @@ def main():
     
     # Generate visualizations
     output_image = utils.plot_boxes(sized_image, output, labels)
-    output_filename = utils.plot_boxes(output_image, args.input_image_path)
+    output_filename = utils.save_image_pil(output_image, args.input_image_path)
     print("Annotated image written to", output_filename)
 
 if __name__ == "__main__":

--- a/detectors/python_inference/infer.py
+++ b/detectors/python_inference/infer.py
@@ -58,9 +58,6 @@ def main():
     
     args = parser.parse_args()
     
-    # project_dir = os.path.abspath(os.path.join(os.getcwd(), os.path.pardir))
-    # sys.path.append(project_dir)
-    
     from utils import detector_preprocessor, detector_postprocessor, utils
         
     # Load runtime

--- a/detectors/python_inference/infer.py
+++ b/detectors/python_inference/infer.py
@@ -72,9 +72,7 @@ def main():
     # Read metadata from runtime
     layout_shapes = utils.get_layout_dims(lre.input_layouts, lre.input_shapes)
     input_size = (layout_shapes[0].get('H'), layout_shapes[0].get('W'))
-    print("expected input size: " + str(input_size))
     device = lre.device_type
-    print("expected device: " + str(device))
     
     # Load Image and Labels
     image = utils.load_image_pil(args.input_image_path)

--- a/detectors/python_inference/infer.py
+++ b/detectors/python_inference/infer.py
@@ -8,14 +8,12 @@
 #!/usr/bin/env python
 
 import os
-import sys
-
-from argparse import ArgumentParser
-from pathlib import Path
-
-from pylre import LatentRuntimeEngine
 
 def main():
+    from argparse import ArgumentParser
+    from pathlib import Path
+    
+    from pylre import LatentRuntimeEngine
 
     parser = ArgumentParser(description="Run inference")
     parser.add_argument("--model_binary_path", type=str, default=".", help="Path to LRE object directory.")

--- a/detectors/python_inference/infer.py
+++ b/detectors/python_inference/infer.py
@@ -9,7 +9,6 @@
 
 import os
 import sys
-import cv2
 
 from argparse import ArgumentParser
 from pathlib import Path
@@ -58,26 +57,25 @@ def main():
     )
     
     args = parser.parse_args()
-    # sys.path.append(str(Path(args.model_binary_path))) # If postprocessor is in the model
-    # from processors import general_detection_postprocessor
     
-    project_dir = os.path.abspath(os.path.join(os.getcwd(), os.path.pardir))
-    sys.path.append(project_dir)
+    # project_dir = os.path.abspath(os.path.join(os.getcwd(), os.path.pardir))
+    # sys.path.append(project_dir)
     
     from utils import detector_preprocessor, detector_postprocessor, utils
         
-    # Model Factory
+    # Load runtime
     lre = LatentRuntimeEngine(str(Path(args.model_binary_path) / "modelLibrary.so"))
-    use_fp16 = bool(int(os.getenv("TVM_TENSORRT_USE_FP16", 0)))
-
-    if(use_fp16):
-        lre.set_model_precision("float16")
     print(lre.get_metadata())
 
+    # Set precision
+    use_fp16 = bool(int(os.getenv("TVM_TENSORRT_USE_FP16", 0)))
+    if(use_fp16):
+        lre.set_model_precision("float16")
+
+    # Read metadata from runtime
     layout_shapes = utils.get_layout_dims(lre.input_layouts, lre.input_shapes)
     input_size = (layout_shapes[0].get('H'), layout_shapes[0].get('W'))
     print("expected input size: " + str(input_size))
-
     device = lre.device_type
     print("expected device: " + str(device))
     

--- a/detectors/python_inference/inference_commands.bash
+++ b/detectors/python_inference/inference_commands.bash
@@ -27,12 +27,12 @@ INT8_ACTIVATIONS=$INT8_MODEL/.activations/ # can we throw an error if this does 
 
 echo "FP32..."
 mkdir -p $FLOAT32_MODEL/trt-cache
-TVM_TENSORRT_CACHE_DIR=$FLOAT32_MODEL/trt-cache python3 infer.py --model_binary_path $FLOAT32_MODEL  --input_image $IMAGE_PATH  --labels $LABELS_PATH --model_format $FORMAT --representation $REPRESENTATION --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
+TVM_TENSORRT_CACHE_DIR=$FLOAT32_MODEL/trt-cache python3 infer.py --model_binary_path $FLOAT32_MODEL  --input_image $IMAGE_PATH  --labels $LABELS_PATH --model_format $MODEL_FORMAT --representation $REPRESENTATION --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
 
 echo "FP16..."
 mkdir -p $FLOAT32_MODEL/trt-cache
-TVM_TENSORRT_CACHE_DIR=$FLOAT32_MODEL/trt-cache TVM_TENSORRT_USE_FP16=1 python3 infer.py --model_binary_path $FLOAT32_MODEL  --input_image $IMAGE_PATH --labels $LABELS_PATH --model_format $FORMAT --representation $REPRESENTATION --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
+TVM_TENSORRT_CACHE_DIR=$FLOAT32_MODEL/trt-cache TVM_TENSORRT_USE_FP16=1 python3 infer.py --model_binary_path $FLOAT32_MODEL  --input_image $IMAGE_PATH --labels $LABELS_PATH --model_format $MODEL_FORMAT --representation $REPRESENTATION --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
 
 echo "INT8..."
 mkdir -p $INT8_MODEL/trt-cache
-TVM_TENSORRT_CACHE_DIR=$INT8_MODEL/trt-cache TVM_TENSORRT_USE_INT8=1 TRT_INT8_PATH=$INT8_ACTIVATIONS python3 infer.py --model_binary_path $INT8_MODEL --input_image $IMAGE_PATH --labels $LABELS_PATH --model_format $FORMAT --representation $REPRESENTATION --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
+TVM_TENSORRT_CACHE_DIR=$INT8_MODEL/trt-cache TVM_TENSORRT_USE_INT8=1 TRT_INT8_PATH=$INT8_ACTIVATIONS python3 infer.py --model_binary_path $INT8_MODEL --input_image $IMAGE_PATH --labels $LABELS_PATH --model_format $MODEL_FORMAT --representation $REPRESENTATION --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD

--- a/detectors/python_inference/inference_commands.bash
+++ b/detectors/python_inference/inference_commands.bash
@@ -16,7 +16,6 @@ CONF_THRESHOLD=$6
 IOU_THRESHOLD=$7
 
 IMAGE_PATH=../../sample_images/bus.jpg
-REPRESENTATION=$8
 
 if [ -v MODEL_PATH ];
 then
@@ -27,12 +26,12 @@ INT8_ACTIVATIONS=$INT8_MODEL/.activations/ # can we throw an error if this does 
 
 echo "FP32..."
 mkdir -p $FLOAT32_MODEL/trt-cache
-TVM_TENSORRT_CACHE_DIR=$FLOAT32_MODEL/trt-cache python3 infer.py --model_binary_path $FLOAT32_MODEL  --input_image $IMAGE_PATH  --labels $LABELS_PATH --model_format $MODEL_FORMAT --representation $REPRESENTATION --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
+TVM_TENSORRT_CACHE_DIR=$FLOAT32_MODEL/trt-cache python3 infer.py --model_binary_path $FLOAT32_MODEL  --input_image $IMAGE_PATH  --labels $LABELS_PATH --model_format $MODEL_FORMAT --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
 
 echo "FP16..."
 mkdir -p $FLOAT32_MODEL/trt-cache
-TVM_TENSORRT_CACHE_DIR=$FLOAT32_MODEL/trt-cache TVM_TENSORRT_USE_FP16=1 python3 infer.py --model_binary_path $FLOAT32_MODEL  --input_image $IMAGE_PATH --labels $LABELS_PATH --model_format $MODEL_FORMAT --representation $REPRESENTATION --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
+TVM_TENSORRT_CACHE_DIR=$FLOAT32_MODEL/trt-cache TVM_TENSORRT_USE_FP16=1 python3 infer.py --model_binary_path $FLOAT32_MODEL  --input_image $IMAGE_PATH --labels $LABELS_PATH --model_format $MODEL_FORMAT --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
 
 echo "INT8..."
 mkdir -p $INT8_MODEL/trt-cache
-TVM_TENSORRT_CACHE_DIR=$INT8_MODEL/trt-cache TVM_TENSORRT_USE_INT8=1 TRT_INT8_PATH=$INT8_ACTIVATIONS python3 infer.py --model_binary_path $INT8_MODEL --input_image $IMAGE_PATH --labels $LABELS_PATH --model_format $MODEL_FORMAT --representation $REPRESENTATION --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
+TVM_TENSORRT_CACHE_DIR=$INT8_MODEL/trt-cache TVM_TENSORRT_USE_INT8=1 TRT_INT8_PATH=$INT8_ACTIVATIONS python3 infer.py --model_binary_path $INT8_MODEL --input_image $IMAGE_PATH --labels $LABELS_PATH --model_format $MODEL_FORMAT --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD

--- a/detectors/python_inference/inference_commands.bash
+++ b/detectors/python_inference/inference_commands.bash
@@ -26,12 +26,12 @@ INT8_ACTIVATIONS=$INT8_MODEL/.activations/ # can we throw an error if this does 
 
 echo "FP32..."
 mkdir -p $FLOAT32_MODEL/trt-cache
-TVM_TENSORRT_CACHE_DIR=$FLOAT32_MODEL/trt-cache python3 infer.py --model_binary_path $FLOAT32_MODEL  --input_image $IMAGE_PATH  --labels $LABELS_PATH --model_format $MODEL_FORMAT --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
+TVM_TENSORRT_CACHE_DIR=$FLOAT32_MODEL/trt-cache python3 infer.py --model_binary_path $FLOAT32_MODEL  --input_image_path $IMAGE_PATH  --labels $LABELS_PATH --model_format $MODEL_FORMAT --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
 
 echo "FP16..."
 mkdir -p $FLOAT32_MODEL/trt-cache
-TVM_TENSORRT_CACHE_DIR=$FLOAT32_MODEL/trt-cache TVM_TENSORRT_USE_FP16=1 python3 infer.py --model_binary_path $FLOAT32_MODEL  --input_image $IMAGE_PATH --labels $LABELS_PATH --model_format $MODEL_FORMAT --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
+TVM_TENSORRT_CACHE_DIR=$FLOAT32_MODEL/trt-cache TVM_TENSORRT_USE_FP16=1 python3 infer.py --model_binary_path $FLOAT32_MODEL  --input_image_path $IMAGE_PATH --labels $LABELS_PATH --model_format $MODEL_FORMAT --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
 
 echo "INT8..."
 mkdir -p $INT8_MODEL/trt-cache
-TVM_TENSORRT_CACHE_DIR=$INT8_MODEL/trt-cache TVM_TENSORRT_USE_INT8=1 TRT_INT8_PATH=$INT8_ACTIVATIONS python3 infer.py --model_binary_path $INT8_MODEL --input_image $IMAGE_PATH --labels $LABELS_PATH --model_format $MODEL_FORMAT --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD
+TVM_TENSORRT_CACHE_DIR=$INT8_MODEL/trt-cache TVM_TENSORRT_USE_INT8=1 TRT_INT8_PATH=$INT8_ACTIVATIONS python3 infer.py --model_binary_path $INT8_MODEL --input_image_path $IMAGE_PATH --labels $LABELS_PATH --model_format $MODEL_FORMAT --max_det $MAX_DET --confidence $CONF_THRESHOLD --iou $IOU_THRESHOLD

--- a/detectors/python_inference/utils/detector_postprocessor.py
+++ b/detectors/python_inference/utils/detector_postprocessor.py
@@ -5,9 +5,7 @@
 #  file that should have been included as part of this package.
 
 import torch
-from numpy import ndarray
 from torchvision.ops.boxes import batched_nms
-import itertools
 
 
 def post_process_efficientdet(

--- a/detectors/python_inference/utils/detector_postprocessor.py
+++ b/detectors/python_inference/utils/detector_postprocessor.py
@@ -11,7 +11,7 @@ import itertools
 
 
 # input is size: batch_size x num_anchors_after_top_k x [x_min_abs, y_min_abs, x_max_abs, y_max_abs, top_class_index, top_class_score]
-def post_process_efficientdet_format_for_leip(
+def post_process_efficientdet(
     input, iou_threshold, max_det_per_image, prediction_confidence_threshold
 ):
     """
@@ -38,48 +38,13 @@ def post_process_efficientdet_format_for_leip(
         # Confidence threshold based filtering
         mask = detections[:,4] > prediction_confidence_threshold
         batch_detections.append(detections[mask])
+    
     return batch_detections
-
-
-
-def transform_into_leip_representation(batch_detections, output_format, height, width):
-    from representations.boundingboxes.boundingbox import BoundingBox
-    from representations.boundingboxes.utils import BBFormat
-    postprocessed_batch = []
-    convert_coco80_to_coco91 = (output_format == 'nanodet')
-    coco80_to_coco91_map = [x for x in range(1, 91) if x not in [12, 26, 29, 30, 45, 66, 68, 69, 71, 83]] if convert_coco80_to_coco91 else None
-    for sample_detections in batch_detections:
-        bbs = []
-        for bbox in sample_detections:
-            class_id = coco80_to_coco91_map[bbox[5].int() - 1] if coco80_to_coco91_map else bbox[5].int()
-            bbs.append(
-                BoundingBox(
-                    class_id=class_id,
-                    coords=bbox[:4],
-                    image_size=(width, height),
-                    confidence=bbox[4],
-                    bb_format=BBFormat.pascal_voc,
-                )
-            )
-        postprocessed_batch.append(bbs)
-    return postprocessed_batch
-
-
-def transform_into_AF_representation(batch_detections):
-    from af.core.utils.annotations import BoundingBox2d as bbox2d
-    postprocessed_batch = []
-    for sample_detections in batch_detections:
-        sample_detections = sample_detections.cpu()
-        bbs = []
-        for bbox in sample_detections:
-            bbs.append(bbox2d.from_format('pascal_voc', bbox[:4], label=int(bbox[5]), confidence=bbox[4]))
-        postprocessed_batch.append(bbs)
-    return postprocessed_batch
 
 
 # input is size: batch_size x num_anchors x [x_min_norm,  y_min_norm,  x_max_norm,  y_max_norm, class_0_score, class_1_score ... class_n_score]
 # class_0_score is additional background class which is later ignored
-def transform_ssd_to_efficientdet(input, width, height, **kwargs):
+def transform_ssd_to_efficientdet(input, width, height):
     # Prepare the scaling tensor
     scale_tensor = torch.tensor([width, height, width, height], device=input.device)
 
@@ -98,8 +63,6 @@ def transform_ssd_to_efficientdet(input, width, height, **kwargs):
     return transformed_detections
 
 
-
-
 def transform_yolo_nanodet_to_efficientdet(input):
     """ Translates the decoded nanodet outputs to the format the GPP expects, via a set of vectorized transformations on GPU
     Args:
@@ -109,16 +72,19 @@ def transform_yolo_nanodet_to_efficientdet(input):
         """
     # Extract bounding boxes
     bboxes = input[:, :, :4]
+    
     # Extract class scores and find top classes and scores
     class_scores = input[:, :, 4:]
     top_classes = torch.argmax(class_scores, dim=2)
     top_scores = torch.max(class_scores, dim=2).values
+    
     # Stack transformed detections
     transformed_detections = torch.cat([bboxes, top_classes.unsqueeze(2).float(), top_scores.unsqueeze(2)], dim=2)
+    
     return transformed_detections
 
 
-def postprocess(input, **kwargs):
+def postprocess(input, output_format, input_size, max_det_per_image, prediction_confidence_threshold, iou_threshold):
     """
     Args
         input: List of outputs for a batch, where each output is
@@ -133,20 +99,8 @@ def postprocess(input, **kwargs):
         A Sequence(batch size). Each item in that sequence is a Sequence
         of LEIP representations, either Labels or BoundingBoxes.
     """
-    max_det_per_image = int(kwargs["max_det_per_image"])
-    prediction_confidence_threshold = float(kwargs["prediction_confidence_threshold"])
-    iou_threshold = float(kwargs["iou_threshold"])
-    height = int(kwargs["height"])
-    width = int(kwargs["width"])
-    output_format = kwargs["output_format"]
-    deploy_env = kwargs["deploy_env"]
-    # Deal with different input format when model is ingested via SDK
-    if isinstance(input, list) and isinstance(input[0], ndarray):
-        assert len(input) == 1, f"there is more than one model output, but the general postprocessor you are using expects a single model output"
-        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-        # print("Moving model outputs to CUDA for postprocessing because it is available" if torch.cuda.is_available() else "postprocessing on CPU")
-        input = torch.from_numpy(input[0]).to(device) # only the first element of the list is needed, it also requires numpy -> torch.tensor conversion
-        deploy_env = 'leip'
+    height = input_size[0]
+    width = input_size[1]
     
     # Perform necesary vectorized transformations to adapt decoded model outputs
     if output_format == "ssd":
@@ -155,13 +109,7 @@ def postprocess(input, **kwargs):
         input = transform_yolo_nanodet_to_efficientdet(input)
 
     # Do the Postprocessing: top K filtering -> NMS -> confidence based filtering
-    batch_detections = post_process_efficientdet_format_for_leip(input, iou_threshold, max_det_per_image, prediction_confidence_threshold)
+    batch_detections = post_process_efficientdet(input, iou_threshold, max_det_per_image, prediction_confidence_threshold)
     
-    if deploy_env == 'leip':
-        postprocessed_batch = transform_into_leip_representation(batch_detections, output_format, height, width)
-    elif deploy_env == 'torch':
-        postprocessed_batch = batch_detections
-    else:
-        postprocessed_batch = transform_into_AF_representation(batch_detections)
-    return postprocessed_batch
+    return batch_detections
 

--- a/detectors/python_inference/utils/detector_postprocessor.py
+++ b/detectors/python_inference/utils/detector_postprocessor.py
@@ -10,13 +10,12 @@ from torchvision.ops.boxes import batched_nms
 import itertools
 
 
-# input is size: batch_size x num_anchors_after_top_k x [x_min_abs, y_min_abs, x_max_abs, y_max_abs, top_class_index, top_class_score]
 def post_process_efficientdet(
     input, iou_threshold, max_det_per_image, prediction_confidence_threshold
 ):
     """
     Args
-        input: the decoded box proposals in Efficientdet format. 
+        input: the decoded box proposals in Efficientdet format.
         Dimensions are batch_size x num_anchors_after_top_k x 6; where the 6 stands for [x_min_abs, y_min_abs, x_max_abs, y_max_abs, top_class_index, top_class_score]
     Returns
         A list of length batch_size containing the final boudingboxes as Torch.Tensor [x_min_abs, y_min_abs, x_max_abs, y_max_abs, top_class_score, top_class_index]
@@ -42,9 +41,13 @@ def post_process_efficientdet(
     return batch_detections
 
 
-# input is size: batch_size x num_anchors x [x_min_norm,  y_min_norm,  x_max_norm,  y_max_norm, class_0_score, class_1_score ... class_n_score]
-# class_0_score is additional background class which is later ignored
 def transform_ssd_to_efficientdet(input, width, height):
+    """ Translates the decoded ssd outputs to the format GPP expects
+    Args:
+        input: batch_size x num_anchors x [x_min_norm,  y_min_norm,  x_max_norm,  y_max_norm, class_0_score, class_1_score ... class_n_score]
+    Returns:
+        transformed_detections: Outputs in efficientdet detections format.
+        """
     # Prepare the scaling tensor
     scale_tensor = torch.tensor([width, height, width, height], device=input.device)
 
@@ -53,6 +56,7 @@ def transform_ssd_to_efficientdet(input, width, height):
     bboxes *= scale_tensor
 
     # Extract class scores and find top classes and scores
+    # class_0_score is additional background class which is ignored
     class_scores = input[:, :, 5:]
     top_classes = torch.argmax(class_scores, dim=2)
     top_scores = torch.max(class_scores, dim=2).values
@@ -64,11 +68,11 @@ def transform_ssd_to_efficientdet(input, width, height):
 
 
 def transform_yolo_nanodet_to_efficientdet(input):
-    """ Translates the decoded nanodet outputs to the format the GPP expects, via a set of vectorized transformations on GPU
+    """ Translates the decoded nanodet outputs to the format GPP expects
     Args:
         input: batch_size x num_anchors x [x_min_abs,  y_min_abs,  x_max_abs,  y_max_abs, class_1_score, class_2_score ... class_n_score]
     Returns:
-
+        transformed_detections: Outputs in efficientdet detections format.
         """
     # Extract bounding boxes
     bboxes = input[:, :, :4]
@@ -92,12 +96,15 @@ def postprocess(input, output_format, input_size, max_det_per_image, prediction_
         E.g. print([output.shape for output in outputs]) for three
         outputs of bs 8 will yield something like
           [(8,10,10,5), (8,5), (8,)]
-
-        **kwargs: Not accessible through leip evaluate just yet.
-
+        output_format: By default, efficientdet preprocess transforms are applied.
+        Any other recipe requires setting appropriate input_transform and
+        any new model requires writing custom transforms to match af_preprocess.json.
+        input_size: Input (height, width) expected by the model.
+        max_det_per_image: Maximum detections per image.
+        prediction_confidence_threshold: Prediction confidence threshold.
+        iou_threshold: IOU threshold.
     Returns
-        A Sequence(batch size). Each item in that sequence is a Sequence
-        of LEIP representations, either Labels or BoundingBoxes.
+        batch_detections: A list of box detections (box coordinates, score, class).
     """
     height = input_size[0]
     width = input_size[1]

--- a/detectors/python_inference/utils/detector_preprocessor.py
+++ b/detectors/python_inference/utils/detector_preprocessor.py
@@ -23,20 +23,13 @@ def torch_preprocess_transforms(image, input_transform, input_size):
         resize_var = int(input_size[0] * width_height_image)
     filler = tuple(int(a - b) for a, b in zip(input_size, new_image_size))
     resize_center_color1_transform = transforms.Compose([
-        # transforms.Resize(input_size)
         transforms.Resize(resize_var),  # Equivalent to LongestMaxSize
         transforms.Pad ((0, 0, filler[0], filler[1]), fill=(124, 116, 104), padding_mode='constant'),  # Equivalent to PadIfNeeded
     ])
-    ## Resize is like shortestmaxsize, so I'm forcing 1080 to be 512 by resizing with 512/1080*810.
-    ## Since height then needs padding, I do 512-384. This does not center things.
-    ## Still the boxes are off.
     resize_center_color2_transform = transforms.Compose([
-        # transforms.Resize(input_size)
         transforms.Resize(resize_var),  # Equivalent to LongestMaxSize
         transforms.Pad((int(filler[0]/2), int(filler[1]/2), int(filler[0]/2), int(filler[1]/2)), fill=(128, 128, 128), padding_mode='constant'),  # Equivalent to PadIfNeeded
     ])
-    ## padding makes it look wrong. Why?
-    # if input is padded, the visual image should also be padded
     
     ## Transforms to normalize and tensorize.
     imagenet_normalize = transforms.Compose([

--- a/detectors/python_inference/utils/detector_preprocessor.py
+++ b/detectors/python_inference/utils/detector_preprocessor.py
@@ -4,27 +4,11 @@
 #  and is released under the "Latent AI Commercial Software License". Please see the LICENSE
 #  file that should have been included as part of this package.
 
-def preprocess(image, input_transform, input_size):
-    """
-    Args
-        image: PIL image.
-        input_transform: By default, efficientdet preprocess transforms are applied.
-        Any other recipe requires setting appropriate input_transform and
-        any new model requires writing custom transforms to match af_preprocess.json.
-        input_size: Input (height, width) expected by the model.
-    Returns
-        sized_image: Input PIL image with resizing and padding for visualization.
-        transformed_image: Torch tensor to feed into the model.
-    """
-    
-    # Redirect to a relevant transform library.
-    sized_image, transformed_image = torch_preprocess_transforms(image, input_transform, input_size)
+import torchvision.transforms as transforms
 
-    return sized_image, transformed_image
 
 ## Pytorch transforms
 def torch_preprocess_transforms(image, input_transform, input_size):
-    import torchvision.transforms as transforms
 
     ## Transforms to resize and pad
     resize_transform = transforms.Resize(input_size)
@@ -78,4 +62,23 @@ def torch_preprocess_transforms(image, input_transform, input_size):
         transformed_image = resize_center_color1_transform(image)
         transformed_image = float_normalize(transformed_image)
     
+    return sized_image, transformed_image
+
+
+def preprocess(image, input_transform, input_size):
+    """
+    Args
+        image: PIL image.
+        input_transform: By default, efficientdet preprocess transforms are applied.
+        Any other recipe requires setting appropriate input_transform and
+        any new model requires writing custom transforms to match af_preprocess.json.
+        input_size: Input (height, width) expected by the model.
+    Returns
+        sized_image: Input PIL image with resizing and padding for visualization.
+        transformed_image: Torch tensor to feed into the model.
+    """
+    
+    # Redirect to a relevant transform library.
+    sized_image, transformed_image = torch_preprocess_transforms(image, input_transform, input_size)
+
     return sized_image, transformed_image

--- a/detectors/python_inference/utils/detector_preprocessor.py
+++ b/detectors/python_inference/utils/detector_preprocessor.py
@@ -4,109 +4,29 @@
 #  and is released under the "Latent AI Commercial Software License". Please see the LICENSE
 #  file that should have been included as part of this package.
 
-TRANSFORM_LIBRARY = 'torch' # cv2, torch, or albumentations
-
 def preprocess(image, input_transform, input_size):
     """
     Args
-        input: List of outputs for a batch, where each output is
-        batched and is either a sequence or an ndarray.
-        E.g. print([output.shape for output in outputs]) for three
-        outputs of bs 8 will yield something like
-          [(8,10,10,5), (8,5), (8,)]
-
-        **kwargs: Not accessible through leip evaluate just yet.
-
+        image: PIL image.
+        input_transform: By default, efficientdet preprocess transforms are applied.
+        Any other recipe requires setting appropriate input_transform and
+        any new model requires writing custom transforms to match af_preprocess.json.
+        input_size: Input (height, width) expected by the model.
     Returns
-        A Sequence(batch size). Each item in that sequence is a Sequence
-        of LEIP representations, either Labels or BoundingBoxes.
+        sized_image: Input PIL image with resizing and padding for visualization.
+        transformed_image: Torch tensor to feed into the model.
     """
     
-    if TRANSFORM_LIBRARY == 'albumentations':
-        sized_image, transformed_image = albumentations_preprocess_transforms(image, input_transform, input_size)
-    elif TRANSFORM_LIBRARY == 'torch':
-        sized_image, transformed_image = torch_preprocess_transforms(image, input_transform, input_size)
-    else: # default is cv2
-        sized_image, transformed_image = opencv_preprocess_transforms(image, input_transform, input_size)
+    # Redirect to a relevant transform library.
+    sized_image, transformed_image = torch_preprocess_transforms(image, input_transform, input_size)
 
     return sized_image, transformed_image
 
-## Albumentations processors
-def load_albumentations_preprocess(image, albumentations_path):
-    # Albumentations Pre-process
-    import albumentations as A
-    loaded_transform = A.load(albumentations_path)
-    loaded_transform.processors.pop("keypoints")
-    loaded_transform.processors.pop("bboxes")
-    print(loaded_transform)
-
-    transformed_image = loaded_transform(image=image)['image']
-    transformed_image = transformed_image.contiguous()
-
-    return transformed_image
-
-def albumentations_preprocess_transforms(image, input_transform, input_size):
-    import albumentations as A
-    from albumentations.pytorch import ToTensorV2
-
-    ## transforms
-    resize_transform = A.Compose([
-        A.Resize(p=1, height=input_size[0], width=input_size[0], interpolation=1),
-    ], p=1.0)
-    resize_center_color1_transform = A.Compose([
-        A.LongestMaxSize(p=1, max_size=max(input_size), interpolation=1),
-        A.PadIfNeeded(p=1, min_height=input_size[0], min_width=input_size[1], border_mode=0, value=[124, 116, 104]),
-    ], p=1.0)
-    resize_center_color2_transform = A.Compose([
-        A.LongestMaxSize(p=1, max_size=max(input_size), interpolation=1),
-        A.PadIfNeeded(p=1, min_height=input_size[0], min_width=input_size[1], border_mode=0, value=[128, 128, 128]),
-    ], p=1.0)
-    float_normalize = A.Compose([
-        A.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225], max_pixel_value=255.0),
-        ToTensorV2(p=1, transpose_mask=False),
-    ], p=1.0)
-    int_normalize = A.Compose([
-        A.Normalize(mean=[0, 0, 0], std=[1, 1, 1], max_pixel_value=1),
-        ToTensorV2(p=1, transpose_mask=False),
-    ], p=1.0)
-    # this transform is incorrect
-
-    ## image
-    if input_transform == 'ssd':   
-        sized_image = resize_transform(image=image)   
-    elif input_transform == 'yolo':   
-        sized_image = resize_center_color2_transform(image=image)
-    elif input_transform == 'nanodet':   
-        sized_image = resize_transform(image=image)
-    else: # default is for efficient det
-        sized_image = resize_center_color1_transform(image=image)
-    
-    sized_image = sized_image['image']
-
-    ## models
-    if input_transform == 'ssd':    
-        transformed_image = resize_transform(image=image)
-        transformed_image = float_normalize(image=transformed_image['image'])
-    elif input_transform == 'yolo':
-        transformed_image = resize_center_color2_transform(image=image)
-        transformed_image = int_normalize(image=transformed_image['image'])
-    elif input_transform == 'nanodet':
-        transformed_image = resize_transform(image=image)
-        transformed_image = float_normalize(image=transformed_image['image'])
-    else: # default is for efficient det
-        transformed_image = resize_center_color1_transform(image=image)
-        transformed_image = float_normalize(image=transformed_image['image'])
-
-    transformed_image = transformed_image['image']
-    transformed_image = transformed_image.contiguous()
-    
-    return sized_image, transformed_image
-
-## Pytorch processors
+## Pytorch transforms
 def torch_preprocess_transforms(image, input_transform, input_size):
     import torchvision.transforms as transforms
 
-    ## transforms
+    ## Transforms to resize and pad
     resize_transform = transforms.Resize(input_size)
     resize_center_color1_transform = transforms.Compose([
         transforms.Resize(input_size)
@@ -123,6 +43,8 @@ def torch_preprocess_transforms(image, input_transform, input_size):
     ])
     ## padding makes it look wrong. Why?
     # if input is padded, the visual image should also be padded
+    
+    ## Transforms to normalize and tensorize.
     float_normalize = transforms.Compose([
         transforms.ToTensor(),  # Equivalent to ToTensorV2
         transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
@@ -132,7 +54,7 @@ def torch_preprocess_transforms(image, input_transform, input_size):
         transforms.Normalize(mean=[0, 0, 0], std=[1, 1, 1]),
     ])
 
-    ## image
+    ## Transforms to an image for visualization.
     if input_transform == 'ssd':   
         sized_image = resize_transform(image)   
     elif input_transform == 'yolo':   
@@ -142,7 +64,7 @@ def torch_preprocess_transforms(image, input_transform, input_size):
     else: # default is for efficient det
         sized_image = resize_center_color1_transform(image)
 
-    ## models
+    ## Transforms to an image for inference.
     if input_transform == 'ssd':    
         transformed_image = resize_transform(image)
         transformed_image = float_normalize(transformed_image)
@@ -156,70 +78,4 @@ def torch_preprocess_transforms(image, input_transform, input_size):
         transformed_image = resize_center_color1_transform(image)
         transformed_image = float_normalize(transformed_image)
     
-    return sized_image, transformed_image
-
-## OpenCV processors
-def opencv_preprocess_transforms(image, input_transform, input_size):
-    import cv2
-    
-    ## transforms
-    def resize_transform(image):
-        image = cv2.resize(image, input_size, interpolation=cv2.INTER_LINEAR)
-        return image
-
-    def resize_center_color1_transform(image):
-        min_height, min_width = input_size[0], input_size[1]
-        pad_color = [124, 116, 104]
-        height, width, _ = image.shape
-        top_pad = max(0, min_height - height)
-        bottom_pad = max(0, min_height - height - top_pad)
-        left_pad = max(0, min_width - width)
-        right_pad = max(0, min_width - width - left_pad)
-        image = cv2.copyMakeBorder(image, top_pad, bottom_pad, left_pad, right_pad, cv2.BORDER_CONSTANT, value=pad_color)
-        return image
-
-    def resize_center_color2_transform(image):
-        return image
-
-    def float_normalize(image):
-        mean = [0.485, 0.456, 0.406]
-        std = [0.229, 0.224, 0.225]
-        image = (image / 255.0 - mean) / std
-        return image
-
-    def int_normalize(image):
-        mean = [0, 0, 0]
-        std = [1, 1, 1]
-        image = (image / 255.0 - mean) / std
-        return image
-
-    ## image
-    if input_transform == 'ssd':   
-        sized_image = resize_transform(image)   
-    elif input_transform == 'yolo':   
-        sized_image = resize_center_color2_transform(image)
-    elif input_transform == 'nanodet':   
-        sized_image = resize_transform(image)
-    else: # default is for efficient det
-        sized_image = resize_center_color1_transform(image)
-
-    ## models
-    if input_transform == 'ssd':    
-        transformed_image = resize_transform(image)
-        transformed_image = float_normalize(transformed_image)
-    elif input_transform == 'yolo':
-        transformed_image = resize_center_color2_transform(image)
-        transformed_image = int_normalize(transformed_image)
-    elif input_transform == 'nanodet':
-        transformed_image = resize_transform(image)
-        transformed_image = float_normalize(transformed_image)
-    else: # default is for efficient det
-        transformed_image = resize_center_color1_transform(image)
-        transformed_image = float_normalize(transformed_image)
-
-    transformed_image = cv2.dnn.blobFromImage(transformed_image, 
-                                  scalefactor=1/255,
-                                  size=input_size,
-                                  swapRB=True)
-
     return sized_image, transformed_image

--- a/detectors/python_inference/utils/detector_preprocessor.py
+++ b/detectors/python_inference/utils/detector_preprocessor.py
@@ -12,29 +12,39 @@ def torch_preprocess_transforms(image, input_transform, input_size):
 
     ## Transforms to resize and pad
     resize_transform = transforms.Resize(input_size)
+    image_size = image.size
+    width_height_image = image_size[0]/image_size[1]
+    width_height_expected = input_size[0]/input_size[1]
+    if width_height_image > width_height_expected:
+        new_image_size = (input_size[0], input_size[1] / width_height_image)
+        resize_var = int(input_size[1] / width_height_image)
+    else:
+        new_image_size = (input_size[0] * width_height_image, input_size[1])
+        resize_var = int(input_size[0] * width_height_image)
+    filler = tuple(int(a - b) for a, b in zip(input_size, new_image_size))
     resize_center_color1_transform = transforms.Compose([
-        transforms.Resize(input_size)
-        # transforms.Resize(384),  # Equivalent to LongestMaxSize
-        # transforms.Pad ((0, 0, 512-384, 0), fill=(124, 116, 104), padding_mode='constant'),  # Equivalent to PadIfNeeded
+        # transforms.Resize(input_size)
+        transforms.Resize(resize_var),  # Equivalent to LongestMaxSize
+        transforms.Pad ((0, 0, filler[0], filler[1]), fill=(124, 116, 104), padding_mode='constant'),  # Equivalent to PadIfNeeded
     ])
     ## Resize is like shortestmaxsize, so I'm forcing 1080 to be 512 by resizing with 512/1080*810.
     ## Since height then needs padding, I do 512-384. This does not center things.
     ## Still the boxes are off.
     resize_center_color2_transform = transforms.Compose([
-        transforms.Resize(input_size)
-        # transforms.Resize(480),  # Equivalent to LongestMaxSize
-        # transforms.Pad((80, 0, 80, 0), fill=(128, 128, 128), padding_mode='constant'),  # Equivalent to PadIfNeeded
+        # transforms.Resize(input_size)
+        transforms.Resize(resize_var),  # Equivalent to LongestMaxSize
+        transforms.Pad((int(filler[0]/2), int(filler[1]/2), int(filler[0]/2), int(filler[1]/2)), fill=(128, 128, 128), padding_mode='constant'),  # Equivalent to PadIfNeeded
     ])
     ## padding makes it look wrong. Why?
     # if input is padded, the visual image should also be padded
     
     ## Transforms to normalize and tensorize.
-    float_normalize = transforms.Compose([
-        transforms.ToTensor(),  # Equivalent to ToTensorV2
+    imagenet_normalize = transforms.Compose([
+        transforms.ToTensor(),
         transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
     ])
-    int_normalize = transforms.Compose([
-        transforms.ToTensor(),  # Equivalent to ToTensorV2
+    pixel_normalize = transforms.Compose([
+        transforms.ToTensor(),
         transforms.Normalize(mean=[0, 0, 0], std=[1, 1, 1]),
     ])
 
@@ -51,16 +61,16 @@ def torch_preprocess_transforms(image, input_transform, input_size):
     ## Transforms to an image for inference.
     if input_transform == 'ssd':    
         transformed_image = resize_transform(image)
-        transformed_image = float_normalize(transformed_image)
+        transformed_image = imagenet_normalize(transformed_image)
     elif input_transform == 'yolo':
         transformed_image = resize_center_color2_transform(image)
-        transformed_image = int_normalize(transformed_image)
+        transformed_image = pixel_normalize(transformed_image)
     elif input_transform == 'nanodet':
         transformed_image = resize_transform(image)
-        transformed_image = float_normalize(transformed_image)
+        transformed_image = imagenet_normalize(transformed_image)
     else: # default is for efficient det
         transformed_image = resize_center_color1_transform(image)
-        transformed_image = float_normalize(transformed_image)
+        transformed_image = imagenet_normalize(transformed_image)
     
     return sized_image, transformed_image
 

--- a/detectors/python_inference/utils/utils.py
+++ b/detectors/python_inference/utils/utils.py
@@ -6,8 +6,6 @@ import numpy as np
 import os
 from pathlib import Path
 
-VISUALIZATION_LIBRARY = 'pil' # 'pil' 'cv2'
-
 ########################
 ##### Data loaders #####
 ########################
@@ -16,7 +14,6 @@ def load_labels(path):
         return f.read().strip().split("\n")
 
 def load_image_pil(path):
-    # perhaps add a cv version too?
     from PIL import Image
     image = Image.open(path)
     return image
@@ -24,7 +21,6 @@ def load_image_pil(path):
 def load_image_cv(path):
     image = cv2.imread(path, )
     image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB) # cv reads in BGR
-    # cv2.imwrite('/workspace/example-applications/sample_images/cv2_im.jpg',image)
     return image
 
 ########################
@@ -78,62 +74,31 @@ def plot_one_box(box, img, color, label=None, line_thickness=None):
 
     return img
 
-def plot_boxes(deploy_env, image, labels, output, args):
-    if deploy_env == 'leip':
-        from representations.boundingboxes.utils import BBFormat
-        rgb_img = image.convert("RGB")
-        out_im = np.array(cv2.cvtColor(np.array(rgb_img), cv2.COLOR_BGR2RGB))
-        threshold = 0.3
-        for bb in output:
-            for i in range(0,len(bb)):
-                if bb[i].get_confidence() > threshold:
-                    out_im = plot_one_box(
-                        bb[i].get_coordinates(BBFormat.absolute_xyx2y2, image_size=rgb_img.size),
-                        out_im,
-                        color=(255, 0, 0),
-                        label=labels[bb[i].get_class_id()],
-                    )
+def plot_boxes(image, output, labels): 
+    from torchvision.utils import draw_bounding_boxes
+    pil_transform = transforms.PILToTensor()
+    output_image = pil_transform(image)
+    for bb in output:
+        for i in range(0,len(bb)):
+            box = bb[i][0:4]
+            box[0] = box[0] #*orig_size[0]/image_size[0]
+            box[1] = box[1] #*orig_size[1]/image_size[1]
+            box[2] = box[2] #*orig_size[0]/image_size[0]
+            box[3] = box[3] #*orig_size[1]/image_size[1]
+            box = box.unsqueeze(0)
+            label = [labels[int(bb[i][5])]]
+            output_image = draw_bounding_boxes(output_image, box, label, 
+                width=5, colors="blue", fill=False) 
+                # font="serif", font_size=30)
+    
+    return output_image
 
-    elif deploy_env == 'torch' and VISUALIZATION_LIBRARY == 'pil':
-        from torchvision.utils import draw_bounding_boxes
-        pil_transform = transforms.PILToTensor()
-        out_im = pil_transform(image)
-        for bb in output:
-            for i in range(0,len(bb)):
-                box = bb[i][0:4]
-                box[0] = box[0] #*orig_size[0]/image_size[0]
-                box[1] = box[1] #*orig_size[1]/image_size[1]
-                box[2] = box[2] #*orig_size[0]/image_size[0]
-                box[3] = box[3] #*orig_size[1]/image_size[1]
-                box = box.unsqueeze(0)
-                label = [labels[int(bb[i][5])]]
-                out_im = draw_bounding_boxes(out_im, box, label, 
-                    width=5, colors="blue", fill=False) 
-                    # font="serif", font_size=30)
-        pil_to_transform = transforms.ToPILImage()
-        out_im = pil_to_transform(out_im)
-    
-    elif deploy_env == 'torch' and VISUALIZATION_LIBRARY == 'cv2':
-        # rgb_img = image.convert("RGB")
-        out_im = np.array(cv2.cvtColor(np.array(image), cv2.COLOR_BGR2RGB))
-        for bb in output:
-            for i in range(0,len(bb)):
-                box = bb[i][0:4]
-                # box = box.unsqueeze(0)
-                label = labels[int(bb[i][5])]
-                out_im = plot_one_box(
-                    box,
-                    out_im,
-                    color=(255, 0, 0),
-                    label=label,
-                )
-    
-    p = os.path.splitext(args.input_image_path)
+
+def save_image_pil(input, image_path):
+    pil_to_transform = transforms.ToPILImage()
+    output_image = pil_to_transform(input)
+
+    p = os.path.splitext(image_path)
     output_filename = f"{p[0]}-{datetime.datetime.now()}{p[1]}"
-    if deploy_env == 'leip':
-        cv2.imwrite(output_filename, out_im)
-    elif deploy_env == 'torch' and VISUALIZATION_LIBRARY == 'pil':
-        out_im.save(output_filename)
-    elif deploy_env == 'torch' and VISUALIZATION_LIBRARY == 'cv2':
-        cv2.imwrite(output_filename, out_im)
+    output_image.save(output_filename)
     return output_filename

--- a/detectors/python_inference/utils/utils.py
+++ b/detectors/python_inference/utils/utils.py
@@ -6,6 +6,7 @@ import numpy as np
 import os
 from pathlib import Path
 
+
 ########################
 ##### Data loaders #####
 ########################
@@ -13,15 +14,18 @@ def load_labels(path):
     with open(path, "r") as f:
         return f.read().strip().split("\n")
 
+
 def load_image_pil(path):
     from PIL import Image
     image = Image.open(path)
     return image
 
+
 def load_image_cv(path):
     image = cv2.imread(path, )
     image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB) # cv reads in BGR
     return image
+
 
 ########################
 ### Metadata readers ###
@@ -43,6 +47,7 @@ def get_layout_dims(layout_list, shape_list):
         result.append(layout_dict)
     
     return result
+
 
 ########################
 ##### Box plotters #####
@@ -74,22 +79,19 @@ def plot_one_box(box, img, color, label=None, line_thickness=None):
 
     return img
 
+
 def plot_boxes(image, output, labels): 
-    from torchvision.utils import draw_bounding_boxes
-    pil_transform = transforms.PILToTensor()
-    output_image = pil_transform(image)
+    output_image = np.array(image)
     for bb in output:
         for i in range(0,len(bb)):
             box = bb[i][0:4]
-            box[0] = box[0] #*orig_size[0]/image_size[0]
-            box[1] = box[1] #*orig_size[1]/image_size[1]
-            box[2] = box[2] #*orig_size[0]/image_size[0]
-            box[3] = box[3] #*orig_size[1]/image_size[1]
-            box = box.unsqueeze(0)
-            label = [labels[int(bb[i][5])]]
-            output_image = draw_bounding_boxes(output_image, box, label, 
-                width=5, colors="blue", fill=False) 
-                # font="serif", font_size=30)
+            label = labels[int(bb[i][5])]
+            output_image = plot_one_box(
+                box,
+                output_image,
+                color=(0, 0, 255),
+                label=label,
+            )
     
     return output_image
 


### PR DESCRIPTION
This MR cleans up the code and organization of python example applications:
- cleans up WIP improvements to python example applications such as using albumentations, and opencv
- uses in-house box plotter instead of framework based plotter
- fixes padding in torch
- fixes and removes some FIXIT comments
- add some descriptions to functions and make them consistent